### PR TITLE
Misc. fixes

### DIFF
--- a/fixtures/petstore-base.js
+++ b/fixtures/petstore-base.js
@@ -39,7 +39,7 @@ class PetStoreBase extends gofer_1.default {
         return this.get("/pet/{petId}", {
             endpointName: "getPetById",
             pathParams: {
-                petId: opts.petId
+                petId: `${opts.petId}`
             }
         }).json();
     }
@@ -51,20 +51,20 @@ class PetStoreBase extends gofer_1.default {
                 status: opts.status
             },
             pathParams: {
-                petId: opts.petId
+                petId: `${opts.petId}`
             }
-        }).json();
+        }).rawBody().then(() => { });
     }
     deletePet(opts) {
         return this.delete("/pet/{petId}", {
             endpointName: "deletePet",
             pathParams: {
-                petId: opts.petId
+                petId: `${opts.petId}`
             },
             headers: {
                 api_key: opts.apiKey
             }
-        }).json();
+        }).rawBody().then(() => { });
     }
     uploadFile(opts) {
         return this.post("/pet/{petId}/uploadImage", {
@@ -73,7 +73,7 @@ class PetStoreBase extends gofer_1.default {
                 additionalMetadata: opts.additionalMetadata
             },
             pathParams: {
-                petId: opts.petId
+                petId: `${opts.petId}`
             }
         }).json();
     }
@@ -92,7 +92,7 @@ class PetStoreBase extends gofer_1.default {
         return this.get("/store/order/{orderId}", {
             endpointName: "getOrderById",
             pathParams: {
-                orderId: opts.orderId
+                orderId: `${opts.orderId}`
             }
         }).json();
     }
@@ -100,15 +100,15 @@ class PetStoreBase extends gofer_1.default {
         return this.delete("/store/order/{orderId}", {
             endpointName: "deleteOrder",
             pathParams: {
-                orderId: opts.orderId
+                orderId: `${opts.orderId}`
             }
-        }).json();
+        }).rawBody().then(() => { });
     }
     createUser(user) {
         return this.post("/user", {
             endpointName: "createUser",
             json: user
-        }).json();
+        }).rawBody().then(() => { });
     }
     createUsersWithListInput(users) {
         return this.post("/user/createWithList", {
@@ -128,7 +128,7 @@ class PetStoreBase extends gofer_1.default {
     logoutUser() {
         return this.get("/user/logout", {
             endpointName: "logoutUser"
-        }).json();
+        }).rawBody().then(() => { });
     }
     getUserByName(opts) {
         return this.get("/user/{username}", {
@@ -145,7 +145,7 @@ class PetStoreBase extends gofer_1.default {
                 username: opts.username
             },
             json: opts.body
-        }).json();
+        }).rawBody().then(() => { });
     }
     deleteUser(opts) {
         return this.delete("/user/{username}", {
@@ -153,7 +153,7 @@ class PetStoreBase extends gofer_1.default {
             pathParams: {
                 username: opts.username
             }
-        }).json();
+        }).rawBody().then(() => { });
     }
 }
 exports.PetStoreBase = PetStoreBase;

--- a/fixtures/petstore-base.ts
+++ b/fixtures/petstore-base.ts
@@ -93,7 +93,7 @@ export class PetStoreBase extends Gofer {
     return this.get("/pet/{petId}", {
       endpointName: "getPetById",
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       }
     }).json();
   }
@@ -110,9 +110,9 @@ export class PetStoreBase extends Gofer {
         status: opts.status
       },
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   deletePet(opts: {
@@ -122,12 +122,12 @@ export class PetStoreBase extends Gofer {
     return this.delete("/pet/{petId}", {
       endpointName: "deletePet",
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       },
       headers: {
         api_key: opts.apiKey
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   uploadFile(opts: {
@@ -140,7 +140,7 @@ export class PetStoreBase extends Gofer {
         additionalMetadata: opts.additionalMetadata
       },
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       }
     }).json();
   }
@@ -164,7 +164,7 @@ export class PetStoreBase extends Gofer {
     return this.get("/store/order/{orderId}", {
       endpointName: "getOrderById",
       pathParams: {
-        orderId: opts.orderId
+        orderId: `${opts.orderId}`
       }
     }).json();
   }
@@ -175,16 +175,16 @@ export class PetStoreBase extends Gofer {
     return this.delete("/store/order/{orderId}", {
       endpointName: "deleteOrder",
       pathParams: {
-        orderId: opts.orderId
+        orderId: `${opts.orderId}`
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   createUser(user?: User): Promise<void> {
     return this.post("/user", {
       endpointName: "createUser",
       json: user
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   createUsersWithListInput(users?: User[]): Promise<User> {
@@ -210,7 +210,7 @@ export class PetStoreBase extends Gofer {
   logoutUser(): Promise<void> {
     return this.get("/user/logout", {
       endpointName: "logoutUser"
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   getUserByName(opts: {
@@ -234,7 +234,7 @@ export class PetStoreBase extends Gofer {
         username: opts.username
       },
       json: opts.body
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   deleteUser(opts: {
@@ -245,7 +245,7 @@ export class PetStoreBase extends Gofer {
       pathParams: {
         username: opts.username
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
 }

--- a/fixtures/petstore2-base.ts
+++ b/fixtures/petstore2-base.ts
@@ -46,7 +46,7 @@ export default class PetStore2Base extends OtherLib {
     return this.post("/pet/{petId}/uploadImage", {
       endpointName: "uploadFile",
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       }
     }).json();
   }
@@ -55,14 +55,14 @@ export default class PetStore2Base extends OtherLib {
     return this.post("/pet", {
       endpointName: "addPet",
       json: pet
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   updatePet(pet: Pet): Promise<void> {
     return this.put("/pet", {
       endpointName: "updatePet",
       json: pet
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   findPetsByStatus(opts: {
@@ -93,7 +93,7 @@ export default class PetStore2Base extends OtherLib {
     return this.get("/pet/{petId}", {
       endpointName: "getPetById",
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       }
     }).json();
   }
@@ -104,9 +104,9 @@ export default class PetStore2Base extends OtherLib {
     return this.post("/pet/{petId}", {
       endpointName: "updatePetWithForm",
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   deletePet(opts: {
@@ -116,12 +116,12 @@ export default class PetStore2Base extends OtherLib {
     return this.delete("/pet/{petId}", {
       endpointName: "deletePet",
       pathParams: {
-        petId: opts.petId
+        petId: `${opts.petId}`
       },
       headers: {
         api_key: opts.apiKey
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   getInventory(): Promise<Record<string, number>> {
@@ -143,7 +143,7 @@ export default class PetStore2Base extends OtherLib {
     return this.get("/store/order/{orderId}", {
       endpointName: "getOrderById",
       pathParams: {
-        orderId: opts.orderId
+        orderId: `${opts.orderId}`
       }
     }).json();
   }
@@ -154,16 +154,16 @@ export default class PetStore2Base extends OtherLib {
     return this.delete("/store/order/{orderId}", {
       endpointName: "deleteOrder",
       pathParams: {
-        orderId: opts.orderId
+        orderId: `${opts.orderId}`
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   createUsersWithListInput(users: User[]): Promise<void> {
     return this.post("/user/createWithList", {
       endpointName: "createUsersWithListInput",
       json: users
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   getUserByName(opts: {
@@ -187,7 +187,7 @@ export default class PetStore2Base extends OtherLib {
         username: opts.username
       },
       json: opts.body
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   deleteUser(opts: {
@@ -198,7 +198,7 @@ export default class PetStore2Base extends OtherLib {
       pathParams: {
         username: opts.username
       }
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   loginUser(opts: {
@@ -217,21 +217,21 @@ export default class PetStore2Base extends OtherLib {
   logoutUser(): Promise<void> {
     return this.get("/user/logout", {
       endpointName: "logoutUser"
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   createUsersWithArrayInput(users: User[]): Promise<void> {
     return this.post("/user/createWithArray", {
       endpointName: "createUsersWithArrayInput",
       json: users
-    }).json();
+    }).rawBody().then(() => {});
   }
 
   createUser(user: User): Promise<void> {
     return this.post("/user", {
       endpointName: "createUser",
       json: user
-    }).json();
+    }).rawBody().then(() => {});
   }
 
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,7 +48,7 @@ prog
     .addOption(new commander_1.Option('-t, --target <jstarget>', 'With --format=js, what language target; default is auto-inferred from node.engines')
     .default((0, infer_target_1.inferTarget)())
     .choices(Object.keys(typescript_1.ScriptTarget).filter(k => /^ES/.test(k))))
-    .argument('[path-to-spec-file.yml|json]', 'JSON or YAML OpenAPI 3.x spec file; default: stdin')
+    .argument('[path-to-spec-file.yml|json]', 'JSON or YAML OpenAPI 2.x or 3.x spec file; default: stdin')
     .allowExcessArguments(false);
 prog.parse(process.argv);
 const { args } = prog;

--- a/lib/endpoints/index.js
+++ b/lib/endpoints/index.js
@@ -115,17 +115,23 @@ function generateEndpoints({ paths, components = {}, }) {
             const { goferMethod, responseType, acceptMimeType } = (0, response_type_1.default)(responses, components);
             if (acceptMimeType)
                 addAcceptHeader(fetchOpts, acceptMimeType);
+            let fetchCallChain = 
+            // this.get(...).json()
+            t.callExpression(
+            // this.get(...).json
+            t.memberExpression(
+            // this.get(...)
+            t.callExpression(
+            // this.get
+            t.memberExpression(t.thisExpression(), t.identifier(method.toLowerCase())), fetchArgs), t.identifier(goferMethod)), []);
+            // if method is void-returning, absorb the output of the .rawBody()
+            // with a .then(() => {}) to make the types happy
+            if (t.isVoidTypeAnnotation(responseType)) {
+                fetchCallChain = t.callExpression(t.memberExpression(fetchCallChain, t.identifier('then')), [t.arrowFunctionExpression([], t.blockStatement([]))]);
+            }
             const classMethod = t.classMethod('method', t.identifier((0, lodash_camelcase_1.default)(operationId)), methodArgs, t.blockStatement([
                 // return this.get('/foo', { ... }).json();
-                t.returnStatement(
-                // this.get(...).json()
-                t.callExpression(
-                // this.get(...).json
-                t.memberExpression(
-                // this.get(...)
-                t.callExpression(
-                // this.get
-                t.memberExpression(t.thisExpression(), t.identifier(method.toLowerCase())), fetchArgs), t.identifier(goferMethod)), [])),
+                t.returnStatement(fetchCallChain),
             ]));
             return Object.assign(classMethod, {
                 returnType: t.typeAnnotation(t.genericTypeAnnotation(t.identifier('Promise'), t.typeParameterInstantiation([responseType]))),

--- a/lib/endpoints/index.js
+++ b/lib/endpoints/index.js
@@ -112,6 +112,9 @@ function generateEndpoints({ paths, components = {}, }) {
                 // this.get('/path', { ... })
                 fetchOpts.push(...paramFetchOpts);
             }
+            const { goferMethod, responseType, acceptMimeType } = (0, response_type_1.default)(responses, components);
+            if (acceptMimeType)
+                addAcceptHeader(fetchOpts, acceptMimeType);
             const classMethod = t.classMethod('method', t.identifier((0, lodash_camelcase_1.default)(operationId)), methodArgs, t.blockStatement([
                 // return this.get('/foo', { ... }).json();
                 t.returnStatement(
@@ -122,11 +125,10 @@ function generateEndpoints({ paths, components = {}, }) {
                 // this.get(...)
                 t.callExpression(
                 // this.get
-                t.memberExpression(t.thisExpression(), t.identifier(method.toLowerCase())), fetchArgs), t.identifier('json')), [])),
+                t.memberExpression(t.thisExpression(), t.identifier(method.toLowerCase())), fetchArgs), t.identifier(goferMethod)), [])),
             ]));
-            const responseType = (0, response_type_1.default)(responses, components);
             return Object.assign(classMethod, {
-                returnType: t.typeAnnotation(responseType),
+                returnType: t.typeAnnotation(t.genericTypeAnnotation(t.identifier('Promise'), t.typeParameterInstantiation([responseType]))),
             });
         });
     });
@@ -134,4 +136,17 @@ function generateEndpoints({ paths, components = {}, }) {
 exports.default = generateEndpoints;
 function generateOperationId(method, path) {
     return (0, lodash_camelcase_1.default)(method + path);
+}
+/**
+ * ensure we have { headers: { accept: 'some/type' } }
+ */
+function addAcceptHeader(fetchOpts, acceptMimeType) {
+    let headersOpt = fetchOpts.find(o => t.isIdentifier(o.key, { name: 'headers' }));
+    if (!headersOpt) {
+        headersOpt = t.objectProperty(t.identifier('headers'), t.objectExpression([]));
+        fetchOpts.push(headersOpt);
+    }
+    if (t.isObjectExpression(headersOpt.value)) {
+        headersOpt.value.properties.push(t.objectProperty(t.identifier('accept'), t.stringLiteral(acceptMimeType)));
+    }
 }

--- a/lib/endpoints/parse-parameters.js
+++ b/lib/endpoints/parse-parameters.js
@@ -99,15 +99,20 @@ function parseParameters(parameters, components) {
         }
         const { in: section, name, schema, required } = param;
         const camelName = (0, lodash_camelcase_1.default)(name);
+        const paramInfo = {
+            name,
+            camelName,
+            isString: !(schema && 'type' in schema && schema.type !== 'string'),
+        };
         switch (section) {
             case 'query':
-                params.qs.push([name, camelName]);
+                params.qs.push(paramInfo);
                 break;
             case 'path':
-                params.pathParams.push([name, camelName]);
+                params.pathParams.push(paramInfo);
                 break;
             case 'header':
-                params.headers.push([name, camelName]);
+                params.headers.push(paramInfo);
                 break;
             case 'body':
                 hasBody = true;
@@ -117,7 +122,7 @@ function parseParameters(parameters, components) {
                 continue;
         }
         const annotation = schema
-            ? (0, schema_1.schemaToAnnotation)(schema)
+            ? (0, schema_1.schemaToAnnotation)(schema, [name])
             : t.stringTypeAnnotation();
         optTypeProps.push(Object.assign(t.objectTypeProperty(t.identifier(camelName), annotation), {
             optional: !required,
@@ -151,7 +156,19 @@ function parseParameters(parameters, components) {
         // { qs: { foo: opts.foo , ... }, pathParams: ... }
         fetchOpts = Object.entries(params).flatMap(([opt, vars]) => vars.length > 0
             ? [
-                t.objectProperty(t.identifier(opt), t.objectExpression(vars.map(([name, camelName]) => t.objectProperty(idOrLiteral(name), t.memberExpression(t.identifier('opts'), t.identifier(camelName)))))),
+                t.objectProperty(t.identifier(opt), t.objectExpression(vars.map(({ name, camelName, isString }) => {
+                    let value = t.memberExpression(t.identifier('opts'), t.identifier(camelName));
+                    if (opt === 'pathParams' && !isString) {
+                        // if we didn't get a string, and we need a string,
+                        // wrap it:
+                        // opts.foo -> `${opts.foo}`
+                        value = t.templateLiteral([
+                            t.templateElement({ raw: '' }),
+                            t.templateElement({ raw: '' }),
+                        ], [value]);
+                    }
+                    return t.objectProperty(idOrLiteral(name), value);
+                }))),
             ]
             : []);
         if (hasBody) {

--- a/lib/endpoints/response-type.d.ts
+++ b/lib/endpoints/response-type.d.ts
@@ -1,3 +1,7 @@
 import * as t from '@babel/types';
 import type { OpenAPIV3 as o } from 'openapi-types';
-export default function buildResponseType(responses: o.ResponsesObject, components: o.ComponentsObject): t.GenericTypeAnnotation;
+export default function buildResponseType(responses: o.ResponsesObject, components: o.ComponentsObject): {
+    goferMethod: string;
+    responseType: t.FlowType;
+    acceptMimeType?: string;
+};

--- a/lib/endpoints/response-type.js
+++ b/lib/endpoints/response-type.js
@@ -74,9 +74,9 @@ responses, components) {
     // 3. any other unknown type(s) exist
     //    * call .rawBody()
     //    * return type is Buffer
-    // 4. we specifically have a no-content response code (201, 204, etc)
+    // 4. if we have other status codes, then absence of 200 is meaningful, so:
     //    * call .rawBody() to resolve the output promise
-    //    * return type is unknown (should be void, but that's more annoying)
+    //    * return type is void
     // 5. nothing exists - assume a crummy schema and try to be as helpful as
     //    possible
     //    * call .json()
@@ -121,19 +121,13 @@ responses, components) {
             };
         }
     }
-    else if (responses[201] ||
-        responses[202] ||
-        responses[203] ||
-        responses[204]) {
+    else if (Object.keys(responses).length > 0) {
         // (4)
-        debug('Found no-content status code; returning unknown');
-        return {
-            goferMethod: 'rawBody',
-            responseType: t.genericTypeAnnotation(t.identifier('unknown')),
-        };
+        debug('Found non-200 status code(s); returning void');
+        return { goferMethod: 'rawBody', responseType: t.voidTypeAnnotation() };
     }
     // (5)
-    debug('Found no good responses.200.content; returning any');
+    debug('Found no responses.* returning any to be safe');
     return { goferMethod: 'json', responseType: t.anyTypeAnnotation() };
 }
 exports.default = buildResponseType;

--- a/lib/endpoints/response-type.js
+++ b/lib/endpoints/response-type.js
@@ -135,16 +135,16 @@ exports.default = buildResponseType;
  * returns the most preferred mime type, if found
  */
 function findTextType(content) {
+    // start with preference order
     for (const mt of [
         'text/yaml',
         'application/yaml',
         'text/xml',
         'application/xml',
-        'text/plain',
-        'text/html',
     ]) {
         if (mt in content)
             return mt;
     }
-    return null;
+    // fall back on any text type
+    return Object.keys(content).find(mt => mt.startsWith('text/'));
 }

--- a/lib/endpoints/response-type.js
+++ b/lib/endpoints/response-type.js
@@ -18,6 +18,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 /*
  * Copyright (c) 2021, Groupon, Inc.
@@ -50,14 +53,34 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * POSSIBILITY OF SUCH DAMAGE.
  */
 const t = __importStar(require("@babel/types"));
+const debug_1 = __importDefault(require("debug"));
 const refs_1 = require("../refs");
 const schema_1 = require("../schema");
+const debug = (0, debug_1.default)('gofer:openapi:response-type');
 function buildResponseType(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 responses, components) {
-    // if no response declaration, return Promise<void>
-    let typeAnn = t.voidTypeAnnotation();
     // TODO: handle error statuses too
+    // Right now, for success, there's a few possibilities, in decreasing order
+    // of preference:
+    //
+    // 1. application/json exists:
+    //    * call .json()
+    //    * have return type be based on .content.schema if possible, else "any"
+    // 2. one of our known text types exists (xml, yaml, etc)
+    //    * call .text()
+    //    * send { headers: { Accept: <that type> } }
+    //    * return type is "string"
+    // 3. any other unknown type(s) exist
+    //    * call .rawBody()
+    //    * return type is Buffer
+    // 4. we specifically have a no-content response code (201, 204, etc)
+    //    * call .rawBody() to resolve the output promise
+    //    * return type is unknown (should be void, but that's more annoying)
+    // 5. nothing exists - assume a crummy schema and try to be as helpful as
+    //    possible
+    //    * call .json()
+    //    * return type is "any"
     const refOrResp = responses[200];
     if (refOrResp) {
         let resp;
@@ -67,10 +90,67 @@ responses, components) {
         else {
             resp = refOrResp;
         }
-        const respSchema = resp.content?.['application/json']?.schema;
-        if (respSchema)
-            typeAnn = (0, schema_1.schemaToAnnotation)(respSchema);
+        const content = resp.content || {};
+        let textType;
+        if ('application/json' in content) {
+            const respSchema = content['application/json']?.schema;
+            // (1)
+            return {
+                goferMethod: 'json',
+                responseType: respSchema
+                    ? (0, schema_1.schemaToAnnotation)(respSchema, ['application/json'])
+                    : t.anyTypeAnnotation(),
+            };
+        }
+        else if ((textType = findTextType(content))) {
+            // (2)
+            debug('Found text mime type %s', textType);
+            return {
+                goferMethod: 'text',
+                responseType: t.stringTypeAnnotation(),
+                // if there's only one type specified, no need for Accept header
+                acceptMimeType: Object.keys(content).length > 1 ? textType : undefined,
+            };
+        }
+        else if (Object.keys(content).length > 0) {
+            // (3)
+            debug('Found unknown mime type(s); returning Buffer: ', Object.keys(content));
+            return {
+                goferMethod: 'rawBody',
+                responseType: t.genericTypeAnnotation(t.identifier('Buffer')),
+            };
+        }
     }
-    return t.genericTypeAnnotation(t.identifier('Promise'), t.typeParameterInstantiation([typeAnn]));
+    else if (responses[201] ||
+        responses[202] ||
+        responses[203] ||
+        responses[204]) {
+        // (4)
+        debug('Found no-content status code; returning unknown');
+        return {
+            goferMethod: 'rawBody',
+            responseType: t.genericTypeAnnotation(t.identifier('unknown')),
+        };
+    }
+    // (5)
+    debug('Found no good responses.200.content; returning any');
+    return { goferMethod: 'json', responseType: t.anyTypeAnnotation() };
 }
 exports.default = buildResponseType;
+/**
+ * returns the most preferred mime type, if found
+ */
+function findTextType(content) {
+    for (const mt of [
+        'text/yaml',
+        'application/yaml',
+        'text/xml',
+        'application/xml',
+        'text/plain',
+        'text/html',
+    ]) {
+        if (mt in content)
+            return mt;
+    }
+    return null;
+}

--- a/lib/schema.d.ts
+++ b/lib/schema.d.ts
@@ -1,3 +1,3 @@
 import * as t from '@babel/types';
 import type { OpenAPIV3 } from 'openapi-types';
-export declare function schemaToAnnotation(refOrSchema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject): t.FlowType;
+export declare function schemaToAnnotation(refOrSchema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject, path?: string[]): t.FlowType;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -57,14 +57,17 @@ const t = __importStar(require("@babel/types"));
 const debug_1 = __importDefault(require("debug"));
 const refs_1 = require("./refs");
 const debug = (0, debug_1.default)('gofer:openapi:schema');
-function objectTypeAnnotation({ properties = {}, required = [], additionalProperties, }) {
+function objectTypeAnnotation({ properties = {}, required = [], additionalProperties, }, path) {
     const addPropAnn = !!additionalProperties &&
         typeof additionalProperties === 'object' &&
         t.genericTypeAnnotation(t.identifier('Record'), t.typeParameterInstantiation([
             t.stringTypeAnnotation(),
-            schemaToAnnotation(additionalProperties),
+            schemaToAnnotation(additionalProperties, [
+                ...path,
+                'additionalProperties',
+            ]),
         ]));
-    const objAnn = t.objectTypeAnnotation(Object.entries(properties).map(([key, propSchema]) => Object.assign(t.objectTypeProperty(t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key), schemaToAnnotation(propSchema)), { optional: !required.includes(key) })));
+    const objAnn = t.objectTypeAnnotation(Object.entries(properties).map(([key, propSchema]) => Object.assign(t.objectTypeProperty(t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key), schemaToAnnotation(propSchema, [...path, key])), { optional: !required.includes(key) })));
     if (addPropAnn) {
         // if the object is *all* additional properties, just return the Record<>
         // if there are additional properties, include them &'ed with the object
@@ -75,19 +78,23 @@ function objectTypeAnnotation({ properties = {}, required = [], additionalProper
     }
     return objAnn;
 }
-function schemaToAnnotation(refOrSchema) {
+function schemaToAnnotation(refOrSchema, path = []) {
     if ('$ref' in refOrSchema) {
         return t.genericTypeAnnotation(t.identifier((0, refs_1.normalizeRefPath)(refOrSchema.$ref)));
     }
     const schema = refOrSchema;
+    if (!schema.type && schema.properties)
+        schema.type = 'object';
     const { type, anyOf, allOf, enum: enoom } = schema;
-    if (anyOf)
-        return t.unionTypeAnnotation(anyOf.map(schemaToAnnotation));
-    if (allOf)
-        return t.intersectionTypeAnnotation(allOf.map(schemaToAnnotation));
+    if (anyOf) {
+        return t.unionTypeAnnotation(anyOf.map((x, i) => schemaToAnnotation(x, [...path, 'anyOf', `${i}`])));
+    }
+    if (allOf) {
+        return t.intersectionTypeAnnotation(allOf.map((x, i) => schemaToAnnotation(x, [...path, 'allOf', `${i}`])));
+    }
     switch (type) {
         case 'array':
-            return t.arrayTypeAnnotation(schemaToAnnotation(schema.items));
+            return t.arrayTypeAnnotation(schemaToAnnotation(schema.items, [...path, 'items']));
         case 'string':
             if (enoom) {
                 return t.unionTypeAnnotation(enoom.map(e => t.stringLiteralTypeAnnotation(e)));
@@ -102,9 +109,9 @@ function schemaToAnnotation(refOrSchema) {
         case 'boolean':
             return t.booleanTypeAnnotation();
         case 'object':
-            return objectTypeAnnotation(schema);
+            return objectTypeAnnotation(schema, path);
         default:
-            debug(`No handler for type ${type || '<empty>'}`);
+            debug(`%s: No handler for type ${type || '<empty>'}`, path.join('.'));
             return t.anyTypeAnnotation();
     }
 }

--- a/lib/type-decls.js
+++ b/lib/type-decls.js
@@ -18,9 +18,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 /*
  * Copyright (c) 2021, Groupon, Inc.
@@ -53,15 +50,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * POSSIBILITY OF SUCH DAMAGE.
  */
 const t = __importStar(require("@babel/types"));
-const debug_1 = __importDefault(require("debug"));
 const refs_1 = require("./refs");
 const schema_1 = require("./schema");
-const debug = (0, debug_1.default)('gofer:openapi:type-decls');
 function generateTypeDecls(components = {}) {
     const { schemas } = components;
-    return Object.entries(schemas || {}).flatMap(([key, schema]) => {
-        debug(`Schema [${key}]`);
-        return t.exportNamedDeclaration(t.typeAlias(t.identifier((0, refs_1.normalizeRefName)('schemas', key)), null, (0, schema_1.schemaToAnnotation)(schema)));
-    });
+    return Object.entries(schemas || {}).flatMap(([key, schema]) => t.exportNamedDeclaration(t.typeAlias(t.identifier((0, refs_1.normalizeRefName)('schemas', key)), null, (0, schema_1.schemaToAnnotation)(schema, [key]))));
 }
 exports.default = generateTypeDecls;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,7 @@ prog
   )
   .argument(
     '[path-to-spec-file.yml|json]',
-    'JSON or YAML OpenAPI 3.x spec file; default: stdin'
+    'JSON or YAML OpenAPI 2.x or 3.x spec file; default: stdin'
   )
   .allowExcessArguments(false);
 

--- a/src/endpoints/response-type.ts
+++ b/src/endpoints/response-type.ts
@@ -74,7 +74,7 @@ export default function buildResponseType(
       resp = refOrResp;
     }
     const content = resp.content || {};
-    let textType: string | null;
+    let textType: string | undefined;
     if ('application/json' in content) {
       const respSchema = content['application/json']?.schema;
       // (1)
@@ -118,16 +118,17 @@ export default function buildResponseType(
 /**
  * returns the most preferred mime type, if found
  */
-function findTextType(content: Record<string, unknown>): string | null {
+function findTextType(content: Record<string, unknown>): string | undefined {
+  // start with preference order
   for (const mt of [
     'text/yaml',
     'application/yaml',
     'text/xml',
     'application/xml',
-    'text/plain',
-    'text/html',
   ]) {
     if (mt in content) return mt;
   }
-  return null;
+
+  // fall back on any text type
+  return Object.keys(content).find(mt => mt.startsWith('text/'));
 }

--- a/src/endpoints/response-type.ts
+++ b/src/endpoints/response-type.ts
@@ -30,18 +30,41 @@
  */
 import * as t from '@babel/types';
 import type { OpenAPIV3 as o } from 'openapi-types';
+import Debug from 'debug';
+
 import { resolveRef } from '../refs';
 import { schemaToAnnotation } from '../schema';
+
+const debug = Debug('gofer:openapi:response-type');
 
 export default function buildResponseType(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   responses: o.ResponsesObject,
   components: o.ComponentsObject
-) {
-  // if no response declaration, return Promise<void>
-  let typeAnn: t.FlowType = t.voidTypeAnnotation();
-
+): { goferMethod: string; responseType: t.FlowType; acceptMimeType?: string } {
   // TODO: handle error statuses too
+
+  // Right now, for success, there's a few possibilities, in decreasing order
+  // of preference:
+  //
+  // 1. application/json exists:
+  //    * call .json()
+  //    * have return type be based on .content.schema if possible, else "any"
+  // 2. one of our known text types exists (xml, yaml, etc)
+  //    * call .text()
+  //    * send { headers: { Accept: <that type> } }
+  //    * return type is "string"
+  // 3. any other unknown type(s) exist
+  //    * call .rawBody()
+  //    * return type is Buffer
+  // 4. we specifically have a no-content response code (201, 204, etc)
+  //    * call .rawBody() to resolve the output promise
+  //    * return type is unknown (should be void, but that's more annoying)
+  // 5. nothing exists - assume a crummy schema and try to be as helpful as
+  //    possible
+  //    * call .json()
+  //    * return type is "any"
+
   const refOrResp = responses[200];
   if (refOrResp) {
     let resp: o.ResponseObject;
@@ -50,12 +73,69 @@ export default function buildResponseType(
     } else {
       resp = refOrResp;
     }
-    const respSchema = resp.content?.['application/json']?.schema;
-    if (respSchema) typeAnn = schemaToAnnotation(respSchema);
+    const content = resp.content || {};
+    let textType: string | null;
+    if ('application/json' in content) {
+      const respSchema = content['application/json']?.schema;
+      // (1)
+      return {
+        goferMethod: 'json',
+        responseType: respSchema
+          ? schemaToAnnotation(respSchema, ['application/json'])
+          : t.anyTypeAnnotation(),
+      };
+    } else if ((textType = findTextType(content))) {
+      // (2)
+      debug('Found text mime type %s', textType);
+      return {
+        goferMethod: 'text',
+        responseType: t.stringTypeAnnotation(),
+        // if there's only one type specified, no need for Accept header
+        acceptMimeType: Object.keys(content).length > 1 ? textType : undefined,
+      };
+    } else if (Object.keys(content).length > 0) {
+      // (3)
+      debug(
+        'Found unknown mime type(s); returning Buffer: ',
+        Object.keys(content)
+      );
+      return {
+        goferMethod: 'rawBody',
+        responseType: t.genericTypeAnnotation(t.identifier('Buffer')),
+      };
+    }
+  } else if (
+    responses[201] ||
+    responses[202] ||
+    responses[203] ||
+    responses[204]
+  ) {
+    // (4)
+    debug('Found no-content status code; returning unknown');
+    return {
+      goferMethod: 'rawBody',
+      responseType: t.genericTypeAnnotation(t.identifier('unknown')),
+    };
   }
 
-  return t.genericTypeAnnotation(
-    t.identifier('Promise'),
-    t.typeParameterInstantiation([typeAnn])
-  );
+  // (5)
+  debug('Found no good responses.200.content; returning any');
+  return { goferMethod: 'json', responseType: t.anyTypeAnnotation() };
+}
+
+/**
+ * returns the most preferred mime type, if found
+ */
+function findTextType(content: Record<string, unknown>): string | null {
+  for (const mt of [
+    'text/yaml',
+    'application/yaml',
+    'text/xml',
+    'application/xml',
+    'text/plain',
+    'text/html',
+  ]) {
+    if (mt in content) return mt;
+  }
+  return null;
 }

--- a/src/type-decls.ts
+++ b/src/type-decls.ts
@@ -29,27 +29,23 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 import * as t from '@babel/types';
-import Debug from 'debug';
 import type { OpenAPIV3 } from 'openapi-types';
 
 import { normalizeRefName } from './refs';
 import { schemaToAnnotation } from './schema';
-
-const debug = Debug('gofer:openapi:type-decls');
 
 export default function generateTypeDecls(
   components: OpenAPIV3.ComponentsObject = {}
 ): t.ExportNamedDeclaration[] {
   const { schemas } = components;
 
-  return Object.entries(schemas || {}).flatMap(([key, schema]) => {
-    debug(`Schema [${key}]`);
-    return t.exportNamedDeclaration(
+  return Object.entries(schemas || {}).flatMap(([key, schema]) =>
+    t.exportNamedDeclaration(
       t.typeAlias(
         t.identifier(normalizeRefName('schemas', key)),
         null,
-        schemaToAnnotation(schema)
+        schemaToAnnotation(schema, [key])
       )
-    );
-  });
+    )
+  );
 }


### PR DESCRIPTION
* fix: correct --help output
* fix: default to type: 'object'
  It appears to be part of JSON Schema that if you have `properties` even if you don't say `type: 'object'`, that you should treat the thing as an `object` so.... do that
* refactor: improved debugging
* feat: support non-json response types
  Try to handle the types we like first, and fall back on anything
* fix: string-convert all pathParams
* fix: tighten up the void-return handling

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_